### PR TITLE
fixed initialization system-wide installed rvm inside git deploy hooks.

### DIFF
--- a/git/deploy-repo-post-receive
+++ b/git/deploy-repo-post-receive
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 
 cd .. # up from .git/
 unset GIT_DIR # otherwise `git` commands can't see other repos

--- a/git/deploy-repo-pre-receive
+++ b/git/deploy-repo-pre-receive
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 
 cd .. # up from .git/
 unset GIT_DIR # otherwise `git` commands can't see other repos


### PR DESCRIPTION
rvm was not properly initialized inside git deploy hooks when it installed system-wide. 

I've added bash -l flag to force load /etc/profile.d/rvm.sh. That works for me! 

Please, apply this patch if you think it is useful. Thanks!
