### PR TITLE
'user setup for provisioning' dep fails

### DIFF
--- a/ssl.rb
+++ b/ssl.rb
@@ -16,6 +16,7 @@ dep 'passwordless ssh logins', :username, :key do
     shell "mkdir -p -m 700 '#{ssh_dir}'", :sudo => sudo?
     shell "cat >> #{ssh_dir / 'authorized_keys'}", :input => key, :sudo => sudo?
     sudo "chown -R #{username}:#{group} '#{ssh_dir}'" unless ssh_dir.owner == username
+    sudo "chown -R #{username}:#{group} '#{ssh_dir / 'authorized_keys'}'" unless (ssh_dir / 'authorized_keys').owner == username
     shell "chmod 600 #{(ssh_dir / 'authorized_keys')}", :sudo => sudo?
   }
 end


### PR DESCRIPTION
When first creating a user, its home, and providing a key, 

```
shell "cat >> #{ssh_dir / 'authorized_keys'}", :input => key, :sudo => sudo?
```

creates `authorized_keys` belonging to root:root, should be #{username}:#{group}

Change checked and works fine.
